### PR TITLE
locale設定追記

### DIFF
--- a/dockerfile_dbmake.sh
+++ b/dockerfile_dbmake.sh
@@ -73,7 +73,10 @@ RUN echo "export PS1='[\u@\h \W]# '" >> /etc/profile
 
 # centos 日本語設定
 RUN yum -y groupinstall "Japanese Support"
+RUN yum -y reinstall glibc-common
 RUN sed -ri 's/en_US/ja_JP/' /etc/sysconfig/i18n
+RUN localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";
+ENV LANG=ja_JP.UTF-8
 
 # 日本時刻設定
 RUN echo 'ZONE="Asia/Tokyo"' > /etc/sysconfig/clock

--- a/dockerfile_webmake.sh
+++ b/dockerfile_webmake.sh
@@ -65,7 +65,10 @@ RUN echo "export PS1='[\u@\h \W]# '" >> /etc/profile
 
 # centos 日本語設定
 RUN yum -y groupinstall "Japanese Support"
+RUN yum -y reinstall glibc-common
 RUN sed -ri 's/en_US/ja_JP/' /etc/sysconfig/i18n
+RUN localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";
+ENV LANG=ja_JP.UTF-8
 
 # 日本時刻設定
 RUN echo 'ZONE="Asia/Tokyo"' > /etc/sysconfig/clock


### PR DESCRIPTION
Dockerfileでlocaleを指定する方法

ubuntuの場合

<pre>
RUN locale-gen ja_JP.UTF-8  
ENV LANG ja_JP.UTF-8  
ENV LANGUAGE ja_JP:en  
ENV LC_ALL ja_JP.UTF-8  
</pre>


centosの場合

<pre>
RUN yum -y reinstall glibc-common
RUN localedef -v -c -i ja_JP -f UTF-8 ja_JP.UTF-8; echo "";

env LANG=ja_JP.UTF-8
RUN rm -f /etc/localtime
RUN ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
</pre>
